### PR TITLE
RSpec: expect exact exception to avoid RSpec warnings

### DIFF
--- a/spec/pg_tester_spec.rb
+++ b/spec/pg_tester_spec.rb
@@ -32,8 +32,8 @@ describe PgTester do
 
   describe '#initialize' do
     context 'with initdb_path as emtpy' do
-      it 'should raise an error' do
-        expect { described_class.new({:initdb_path => ""}) }.to raise_error
+      it 'raises a RuntimeError' do
+        expect { described_class.new({:initdb_path => ""}) }.to raise_error(RuntimeError)
       end
     end
 


### PR DESCRIPTION
This PR makes the test suite run without outputting the warning:

```
.WARNING: Using the `raise_error` matcher without providing a specific error or 
message risks false positives, since `raise_error` will match when Ruby raises a 
`NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the 
expectation to pass without even executing the method you are intending to call. 
Actual error raised was #<RuntimeError: please install postgresql>. Instead consider 
providing a specific error class or message. This message can be suppressed by setting: 
`RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from 
/opt/src/opensource/ruby/pgtester/spec/pg_tester_spec.rb:36:in `block (4 levels) in <top 
(required)>'.
```
